### PR TITLE
feat(lib/extract_jwt): correctly parse comma terminated token

### DIFF
--- a/lib/extract_jwt.js
+++ b/lib/extract_jwt.js
@@ -58,7 +58,9 @@ extractors.fromAuthHeaderWithScheme = function (auth_scheme) {
         if (request.headers[AUTH_HEADER]) {
             var auth_params = auth_hdr.parse(request.headers[AUTH_HEADER]);
             if (auth_params && auth_scheme_lower === auth_params.scheme.toLowerCase()) {
-                token = auth_params.value;
+                token = auth_params.value.endsWith(",")
+                  ? auth_params.value.split(",")[0]
+                  : auth_params.value;
             }
         }
         return token;

--- a/test/extractors-test.js
+++ b/test/extractors-test.js
@@ -139,8 +139,16 @@ describe('Token extractor', function() {
 
             expect(token).to.equal('abcd123');
         });
-    });
 
+        it('should return the value from the authorization header without a comma at the end', function () {
+            var req = new Request()
+            req.headers['authorization'] = 'test_scheme abcd123,';
+
+            var token = extractor(req);
+
+            expect(token).to.equal('abcd123');
+        });
+    });
 
     describe('fromAuthHeader', function() {
         


### PR DESCRIPTION
My stack is NestJs, Auth0, Passport, and GraphQL.  I noticed that the parsed jwt token from the Authorization Header being passed from [lib/verify_jwt.js#L4](https://github.com/mikenicholson/passport-jwt/blob/master/lib/verify_jwt.js#L4) was including a trailing comma like:

```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c,
```

This fix just checks if the token terminates with a comma and returns it without the comma.

```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
```