### PR TITLE
fix(lib/extract_jwt): make http headers lower case when getting auth token

### DIFF
--- a/lib/extract_jwt.js
+++ b/lib/extract_jwt.js
@@ -55,7 +55,10 @@ extractors.fromAuthHeaderWithScheme = function (auth_scheme) {
     return function (request) {
 
         var token = null;
-        if (request.headers[AUTH_HEADER]) {
+        const lowerCaseHeaders = Object.fromEntries(
+            Object.entries(request.headers).map(([k, v]) => [k.toLowerCase(), v]),
+    );
+        if (lowerCaseHeaders[AUTH_HEADER]) {
             var auth_params = auth_hdr.parse(request.headers[AUTH_HEADER]);
             if (auth_params && auth_scheme_lower === auth_params.scheme.toLowerCase()) {
                 token = auth_params.value;

--- a/lib/extract_jwt.js
+++ b/lib/extract_jwt.js
@@ -59,7 +59,7 @@ extractors.fromAuthHeaderWithScheme = function (auth_scheme) {
             Object.entries(request.headers).map(([k, v]) => [k.toLowerCase(), v]),
     );
         if (lowerCaseHeaders[AUTH_HEADER]) {
-            var auth_params = auth_hdr.parse(request.headers[AUTH_HEADER]);
+            var auth_params = auth_hdr.parse(lowerCaseHeaders[AUTH_HEADER]);
             if (auth_params && auth_scheme_lower === auth_params.scheme.toLowerCase()) {
                 token = auth_params.value;
             }


### PR DESCRIPTION
This should fix a minor anoyance I was having while debugging an `Unauthorized` error and it turns out I made a simple stupid mistake when passing a header.
If by any chance we pass in an upper case header `Authorization`  on the request object this check won't find the JWT.
I admit it may be a bit overkill to convert all headers but it should fix an issue I had while using the package.

Don't know if it should be a specific ES version, hope this is ok and it helps anyone else if they encounter a similar issue 😄   