### PR TITLE
Adding callbacks to options param.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -86,33 +86,44 @@ JwtStrategy.JwtVerifier = require('./verify_jwt');
 
 /**
  * Authenticate request based on JWT obtained from header or post body
+ * The 'options' param has callback functions to substitute calls for injected methods.
+ * This will allow a single instance of this strategy to be used by multiple requests.
+ * @param options
+ *          fail: callback for auth fail,
+ *          error: callback for auth error,
+ *          success: callback for auth success
  */
 JwtStrategy.prototype.authenticate = function(req, options) {
     var self = this;
+    var evts = {
+        fail: options.fail || self.fail,
+        error: options.error || self.error,
+        success: options.success || self.success
+    }
 
     var token = self._jwtFromRequest(req);
 
     if (!token) {
-        return self.fail(new Error("No auth token"));
+        return evts.fail(new Error("No auth token"));
     }
 
     this._secretOrKeyProvider(req, token, function(secretOrKeyError, secretOrKey) {
         if (secretOrKeyError) {
-            self.fail(secretOrKeyError)
+            evts.fail(secretOrKeyError)
         } else {
             // Verify the JWT
             JwtStrategy.JwtVerifier(token, secretOrKey, self._verifOpts, function(jwt_err, payload) {
                 if (jwt_err) {
-                    return self.fail(jwt_err);
+                    return evts.fail(jwt_err);
                 } else {
                     // Pass the parsed token to the user
                     var verified = function(err, user, info) {
                         if(err) {
-                            return self.error(err);
+                            return evts.error(err);
                         } else if (!user) {
-                            return self.fail(info);
+                            return evts.fail(info);
                         } else {
-                            return self.success(user, info);
+                            return evts.success(user, info);
                         }
                     };
 
@@ -123,7 +134,7 @@ JwtStrategy.prototype.authenticate = function(req, options) {
                             self._verify(payload, verified);
                         }
                     } catch(ex) {
-                        self.error(ex);
+                        evts.error(ex);
                     }
                 }
             });


### PR DESCRIPTION
The 'options' param has callback functions to substitute calls for injected methods.
This will allow a single instance of this strategy to be used by multiple requests.