### PR TITLE
Fix CI after merging #238

### DIFF
--- a/.github/scripts/install-peer-deps.sh
+++ b/.github/scripts/install-peer-deps.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+#
+#  Install peer dependencies if running node version < 7.0.0
+#  Version 7 and beyond install peer dependencies by default
+ set -euo pipefail
+
+npm_version="$(npm --version)"
+npm_major_version="${npm_version%%\.*}"
+
+if [[ $npm_major_version -ge 7 ]]; then 
+    echo "NPM version ${npm_version} will automatically install peer dependencies."
+    exit 0
+fi
+
+echo "Installing peer dependencies"
+npm install @nestjs/common reflect-metadata rxjs

--- a/.github/scripts/install-peer-deps.sh
+++ b/.github/scripts/install-peer-deps.sh
@@ -7,7 +7,7 @@
 npm_version="$(npm --version)"
 npm_major_version="${npm_version%%\.*}"
 
-if [[ $npm_major_version -ge 7 ]]; then 
+if [[ $npm_major_version -ge 7 ]]; then
     echo "NPM version ${npm_version} will automatically install peer dependencies."
     exit 0
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci
+      - run: .github/scripts/install-peer-deps.sh
       - run: npm run build --if-present
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x]
+        node-version: [12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Fix CI after merging #238.  The following changes were required:
* Add a script to install peer dependencies for versions of NPM prior to 7
* Remove support for building with node versions <12

This PR also disables the fail-fast option in matrix builds to provide feedback on all versions, even if one fails. 